### PR TITLE
Escape single-quotes in text literals

### DIFF
--- a/sqlgenerate.js
+++ b/sqlgenerate.js
@@ -31,6 +31,7 @@ const joinList = join(', ');
 const terminateStatements = map(concat(__, ';'));
 const containsSelect = (s) => (s.indexOf('SELECT') !== -1);
 const isOfFormat = (n) => compose(equals(n), prop('format'));
+const escapeTextLiteral = (s) => s.replace(/'/g, '\'\'');
 
 var Generator = {
     assignment : (n) => {
@@ -276,7 +277,7 @@ var Generator = {
         trigger : (n) => `"${n.name}"`
     },
     literal : {
-        text : (n) => `'${n.value}'`,
+        text : (n) => `'${escapeTextLiteral(n.value)}'`,
         decimal : (n) => `${n.value}`,
         null : () => 'NULL'
     },

--- a/test/sql/github-issues/escape-single-quote-gh5.sql
+++ b/test/sql/github-issues/escape-single-quote-gh5.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM `bananas`
+WHERE (color = '''red''');


### PR DESCRIPTION
Text literals have any instances of a single quote replaced with two
single quotes.

From the SQLite docs:

> A string constant is formed by enclosing the string in single quotes
> ('). A single quote within the string can be encoded by putting two
> single quotes in a row - as in Pascal. C-style escapes using the
> backslash character are not supported because they are not standard
> SQL.

Source: http://www.sqlite.org/lang_expr.html